### PR TITLE
feat: add the "create-rpm-dir" input that specifies if a rpm directory must be created

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,14 @@ inputs:
       This will be translated into `/data/archives/{project-name}/{version}`
       If this path exist, the action will fail to prevent overwriting existing RPM.
 
+  create-rpm-directory:
+    required: false
+    default: "true"
+    description: >
+      Boolean that specifies if a 'rpm' folder must be created.
+      If set to false, this will be translated into `/data/archives/{project-name}/{version}`
+      If set to true, this will be translated into `/data/archives/{project-name}/{version}/rpm`
+
   rpm-artifact-name:
     required: true
     description: 'Name of the artifact containing the RPM.'
@@ -47,8 +55,10 @@ runs:
         (
           echo "mkdir ${{ inputs.version }}";
           echo "cd ${{ inputs.version }}";
-          echo "mkdir rpm";
-          echo "cd rpm";
+          if [ ${{ inputs.create-rpm-directory }} == "true" ]; then
+            echo "mkdir rpm";
+            echo "cd rpm";
+          fi
           echo "put ./new-rpm/*";
           echo "ls -l";
           echo "exit"


### PR DESCRIPTION
In our case, the "rpm" folder should not be created when we upload new rpm to devarch. For instance, \\devarch\archives\90\32\Installers\linux\Release4 contains all the RPM in the Release4 folder.

That is why I suggest the "**create-rpm-directory**" input that will be equals to true by default so it won't impact the other users.