### PR TITLE
feat: add the "create-rpm-directory" and "override-existing-version" inputs that specifies if the "rpm" or {version} directories must be created

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,7 @@ description: >
   This action must be run on builddocker to be functional.
   This will transfer the RPM to this path: 
   /data/archives/{project-name}/{version}/rpm
+  (unless the inputs `override-existing-version` and `create-rpm-directory` are set)
 
 inputs:
   project-name:  
@@ -29,6 +30,22 @@ inputs:
     required: true
     description: 'Name of the user to be use to connect to devarch with SFTP.'
 
+  override-existing-version:
+    required: false
+    default: "false"
+    description: >
+      Boolean that specifies if we should overwrite the RPM
+      If set to false, the action will fail if the {version} folder already exists
+      If set to true, the action won't fail if the {version} folder already exists and the RPM will be replaced.
+
+  create-rpm-directory:
+    required: false
+    default: "true"
+    description: >
+      Boolean that specifies if a 'rpm' folder must be created.
+      If set to false, this will be translated into `/data/archives/{project-name}/{version}`
+      If set to true, this will be translated into `/data/archives/{project-name}/{version}/rpm`.
+
 runs:
   using: composite
 
@@ -45,10 +62,14 @@ runs:
       # This will prevent overwriting existing rpm
       run: |
         (
-          echo "mkdir ${{ inputs.version }}";
+          if [ ${{ inputs.override-existing-version }} == "false" ]; then
+            echo "mkdir ${{ inputs.version }}"
+          fi
           echo "cd ${{ inputs.version }}";
-          echo "mkdir rpm";
-          echo "cd rpm";
+          if [ ${{ inputs.create-rpm-directory }} == "true" ]; then
+            echo "mkdir rpm";
+            echo "cd rpm";
+          fi
           echo "put ./new-rpm/*";
           echo "ls -l";
           echo "exit"


### PR DESCRIPTION
This action works perfectly for the devarch folders like "DevOps", "CroesusComponents" etc. because the path is formed like so : "{project_name}/{version}/rpm/<rpm_file>".

In contrast, our path are formed as follows : "{project_name}/{version}/<rpm_file**S**>".
For instance, \\devarch\archives\90\32\Installers\linux\Release4 contains **all** the RPM in the same folder.
That is why I suggest the "create-rpm-directory" (=true by default) and "override-existing-version" (=false by default) optional inputs.

## Proposed changes

* If the input "create-rpm-directory" is set to **false**, the "rpm" directory won't be created in devarch
* If the input "override-existing-version" is set to **true**, the {version} directory won't be created in devarch

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if appropriate)
- [x] ~~Any dependent changes have been merged and published in downstream modules~~